### PR TITLE
Add support for browsers installed via snap

### DIFF
--- a/i18n/chromium_de.ts
+++ b/i18n/chromium_de.ts
@@ -44,7 +44,7 @@
     </message>
     <message>
         <source>Show favicons</source>
-        <translation type="unfinished"></translation>
+        <translation>Favicons anzeigen</translation>
     </message>
 </context>
 <context>

--- a/i18n/chromium_en.ts
+++ b/i18n/chromium_en.ts
@@ -24,7 +24,7 @@
     </message>
     <message>
         <source>Show favicons</source>
-        <translation>Favicons anzeigen</translation>
+        <translation>Show favicons</translation>
     </message>
 </context>
 <context>

--- a/i18n/chromium_en.ts
+++ b/i18n/chromium_en.ts
@@ -24,7 +24,7 @@
     </message>
     <message>
         <source>Show favicons</source>
-        <translation>Show favicons</translation>
+        <translation></translation>
     </message>
 </context>
 <context>

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -141,8 +141,8 @@ static vector<path> findBrowserDataDirs()
     for (const auto &data_dir_name : DATA_DIR_NAMES)
     {
         const auto snap_base_path = QDir::homePath() +
-            QStringLiteral("/snap/")
-            + QString::fromStdString(data_dir_name);
+            QStringLiteral("/snap/") +
+            QString::fromStdString(data_dir_name);
 
         std_paths.append(snap_base_path + QStringLiteral("/current/.config/"));
         std_paths.append(snap_base_path + QStringLiteral("/common/"));

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -139,10 +139,14 @@ static vector<path> findBrowserDataDirs()
 #if defined(Q_OS_LINUX)
     // include folders used by browsers installed with snap
     for (const auto &data_dir_name : DATA_DIR_NAMES)
-        std_paths.append(QDir::homePath() +
-            QStringLiteral("/snap/") +
-            QString::fromStdString(data_dir_name) +
-            QStringLiteral("/current/.config/"));
+    {
+        const auto snap_base_path = QDir::homePath() +
+            QStringLiteral("/snap/")
+            + QString::fromStdString(data_dir_name);
+
+        std_paths.append(snap_base_path + QStringLiteral("/current/.config/"));
+        std_paths.append(snap_base_path + QStringLiteral("/common/"));
+    }
 #endif
 
     vector<path> data_dir_paths;

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -4,6 +4,7 @@
 #include "favicons.h"
 #include "plugin.h"
 #include "ui_configwidget.h"
+#include <QDir>
 #include <QFile>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -134,9 +135,18 @@ static vector<path> findBrowserDataDirs()
 #else
     const auto std_loc = QStandardPaths::GenericConfigLocation;
 #endif
+    auto std_paths = QStandardPaths::standardLocations(std_loc);
+#if defined(Q_OS_LINUX)
+    // include folders used by browsers installed with snap
+    for (const auto &data_dir_name : DATA_DIR_NAMES)
+        std_paths.append(QDir::homePath() +
+            QStringLiteral("/snap/") +
+            QString::fromStdString(data_dir_name) +
+            QStringLiteral("/current/.config/"));
+#endif
 
     vector<path> data_dir_paths;
-    for (const auto &std_path : QStandardPaths::standardLocations(std_loc))
+    for (const auto &std_path : std_paths)
         for (const auto &data_dir_name : DATA_DIR_NAMES)
             if (auto data_dir_path = path(std_path.toStdString()) / data_dir_name;
                 exists(data_dir_path))


### PR DESCRIPTION
This adds support for browsers installed via [snap](https://snapcraft.io), a common package manager for Ubuntu.

In snap, the chromium-based browsers config folder seems to be one of:

```
~/snap/<browser_name>/current/.config/<browser_name>/
~/snap/<browser_name>/common/
```
So, I added them both for each browser name in `DATA_DIR_NAMES` array.

Not a C++/Qt expert here, so feel free to modify it. It works here (Ubuntu 25.10 + Vivaldi + Opera + Chromium):

<img width="544" height="326" alt="image" src="https://github.com/user-attachments/assets/ba915a8f-11ef-497c-82cf-11dc110b33b7" />

EDIT: I've also included two commits (sorry) to move the translation of "Show favicons" message to the right place, which would also fix the English version.
