### PR TITLE
fix(#5): make favicon rendering consistent across HiDPI scales

### DIFF
--- a/src/bookmarkitem.cpp
+++ b/src/bookmarkitem.cpp
@@ -20,7 +20,7 @@ struct BookmarkIcon : public Icon
 
     void paint(QPainter *p, const QRect &rect) override
     {
-        const auto size = icon_->actualSize(rect.size(), p->device()->devicePixelRatio());
+        const auto size = icon_->actualSize(rect.size(), p->device()->devicePixelRatioF());
         const auto src_extent = max(size.width(), size.height());
         const auto dst_extent = min(rect.width(), rect.height());
 

--- a/src/favicons.cpp
+++ b/src/favicons.cpp
@@ -21,19 +21,20 @@ struct QImageIcon : public Icon
 
     QImageIcon(QImage img, QString url) : img_(::move(img)), url_(url) { }
 
-    QSize actualSize(const QSize &device_independent_size, double device_pixel_ratio) override
+    QSize actualSize(const QSize &device_independent_size, double) override
     {
         // Downscaled but never larger
-        if (const auto dds = device_independent_size * device_pixel_ratio;
-            dds.width() < img_.width() || dds.height() < img_.height())
-            return img_.size().scaled(dds, Qt::KeepAspectRatio) / device_pixel_ratio;
+        if (device_independent_size.width() < img_.width()
+            || device_independent_size.height() < img_.height())
+            return img_.size().scaled(device_independent_size, Qt::KeepAspectRatio);
         else
-            return img_.size() / device_pixel_ratio;
+            return img_.size();
     }
 
     void paint(QPainter *p, const QRect &rect) override
     {
-        const auto img_device_independent_size = img_.size() / p->device()->devicePixelRatio();
+        const auto img_device_independent_size = actualSize(rect.size(),
+                                                            p->device()->devicePixelRatioF());
         const auto tgt_rect
             = QRect(rect.x() + (rect.width() - img_device_independent_size.width()) / 2,
                     rect.y() + (rect.height() - img_device_independent_size.height()) / 2,


### PR DESCRIPTION
The plugin currently mixes logical and physical pixel units when computing favicon size (#5).  
That causes different icon rendering decisions on different scale factors for identical bookmarks.

### Changes:
- Fix DPI handling in `QImageIcon` by keeping size calculations device-independent.
- Update bookmark icon threshold logic to use `devicePixelRatioF()` for proper HiDPI/fractional scale behavior.
- Prevent rendering mode flips (`star + favicon` vs `iconified favicon`) between 1x and 2x displays.

### Testing:
I built the plugin locally on NixOS, ran Albert with the patched plugin loaded from the local build directory.
Verified bookmark favicon rendering is now consistent. I tried 1080p, 1440p, 5k and scale factors 1, 1.25, 1.5, 2 and 3. All cases are consistnant now. 
Note: I haven't tested it on macOS.

Fixes: #5 